### PR TITLE
improvement(helm): switch helm chart release to OCI push

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -39,13 +39,8 @@ jobs:
         with:
           version: v3.10.0
 
-      - name: Install python
-        uses: actions/setup-python@v4
-
-      - name: Install Cloudsmith CLI
-        run: pip install --upgrade cloudsmith-cli
-
       - name: Build and push helm package to Cloudsmith
         run: sh upload-to-cloudsmith.sh
         env:
           CLOUDSMITH_API_KEY: ${{ secrets.CLOUDSMITH_API_KEY }}
+          CLOUDSMITH_USERNAME: ${{ secrets.CLOUDSMITH_USERNAME }}

--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.1
+version: 0.2.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/upload-to-cloudsmith.sh
+++ b/upload-to-cloudsmith.sh
@@ -1,7 +1,23 @@
+#!/usr/bin/env sh
+set -e
+
+if [ -z "$CLOUDSMITH_API_KEY" ] || [ -z "$CLOUDSMITH_USERNAME" ]; then
+  echo "Error: CLOUDSMITH_API_KEY and CLOUDSMITH_USERNAME environment variables must be set."
+  exit 1
+fi
+
 cd helm
 helm dependency update
 helm package .
+
+# Push to OCI repository
+echo "$CLOUDSMITH_API_KEY" | helm registry login helm.oci.cloudsmith.io \
+  --username "$CLOUDSMITH_USERNAME" \
+  --password-stdin
+
 for i in *.tgz; do
-    [ -f "$i" ] || break
-    cloudsmith push helm --republish infisical/helm-charts "$i"
+  [ -f "$i" ] || break
+  helm push "$i" oci://helm.oci.cloudsmith.io/infisical/helm-charts
 done
+
+helm registry logout helm.oci.cloudsmith.io


### PR DESCRIPTION
The Helm chart release workflow used the Cloudsmith CLI (`cloudsmith push helm`) to publish charts. Cloudsmith also exposes an OCI registry, and pushing via OCI produces the same traditional Helm artifacts (e.g. `index.yaml`, `.tgz` files) while using the standard `helm push` flow.

This change switches the Helm release pipeline to OCI push only, matching the approach used in [infisical-agent-injector](https://github.com/Infisical/infisical-agent-injector/blob/main/upload-to-cloudsmith.sh).